### PR TITLE
Create an option to ask questions on your Scratch account

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Scratch Profile
+    url: https://scratch.mit.edu/users/TheCloudDev/#comments
+    about: Please ask your questions here.


### PR DESCRIPTION
I've created a file that displays a link to your (@The-Cloud-Dev ) Scratch profile, which shows up when creating a new issue. You can read more about issue templates [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository).